### PR TITLE
Capturando errores en caso de que fallen los logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 
 module.exports = async function (config) {
   let logs;
+
   if (!config.logsConfig) {
     // logs en base de datos
     config = defaults(config, {
@@ -26,11 +27,17 @@ module.exports = async function (config) {
     // Cargando modelo
     logs = sequelize.import('src/model');
 
-    // Verificando conexión con la BD
-    await sequelize.authenticate();
+    try {
+      // Verificando conexión con la BD
+      await sequelize.authenticate();
 
-    // Creando las tablas
-    await sequelize.sync();
+      // Creando las tablas
+      await sequelize.sync();
+    } catch (e) {
+      // Algun error con la base de datos
+      console.error('[app-logs] Error al interactuar con la BD:', e.message);
+      // console.error(e);
+    }
   } else {
     // logs en sistema de archivos
     // analizando config, formato esperado
@@ -101,13 +108,18 @@ module.exports = async function (config) {
     }
 
     // creando la instancia de winston
-    logs = winston.createLogger({
-      level,
-      format,
-      transports
-    });
-    logs.useWinston = true; // bandera
-    logs.logsConfig = logsConfig;
+    try {
+      logs = winston.createLogger({
+        level,
+        format,
+        transports
+      });
+      logs.useWinston = true; // bandera
+      logs.logsConfig = logsConfig;
+    } catch (e) {
+      console.error('[app-logs] Error iniciando winston:', e.message);
+      // console.error(e);
+    }
   }
 
   // Cargando los servicios de logs

--- a/src/services.js
+++ b/src/services.js
@@ -146,16 +146,19 @@ module.exports = function logsServices (logs, Sequelize) {
         id: rol.id
       }
     };
+    try {
+      const item = await logs.findOne(cond);
 
-    const item = await logs.findOne(cond);
+      if (item) {
+        const updated = await logs.update(rol, cond);
+        return updated ? logs.findOne(cond) : item;
+      }
 
-    if (item) {
-      const updated = await logs.update(rol, cond);
-      return updated ? logs.findOne(cond) : item;
+      const result = await logs.create(rol);
+      return result.toJSON();
+    } catch (e) {
+      throw e;
     }
-
-    const result = await logs.create(rol);
-    return result.toJSON();
   }
 
   async function deleteItem (id) {
@@ -220,12 +223,16 @@ module.exports = function logsServices (logs, Sequelize) {
       ip
     };
 
-    try {
-      return createOrUpdate(data);
-    } catch (e) {
-      console.error(chalk.red('LOG ERROR:', e.message, e));
-      return undefined;
-    }
+    let r;
+    r = createOrUpdate(data)
+      .then((r) => {
+        return r;
+      })
+      .catch((err) => {
+        console.error(chalk.red('LOG ERROR:', err.message));
+        return undefined;
+      });
+    return r;
   }
 
   async function error (mensaje = 'Error desconocido', tipo = '', error, usuario, ip) {

--- a/tests/bd-tests.js
+++ b/tests/bd-tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('ava');
-const { config, handleFatalError } = require('../src/util');
+let { config, handleFatalError } = require('../src/util');
 const Log = require('../');
 
 let logs;
@@ -225,4 +225,17 @@ test.serial('bd#delete 5', async t => {
   let deleted = await logs.deleteItem(test.idLog4);
 
   t.true(deleted, 'log 5 eliminado');
+});
+
+test.serial('bd#desconexionError - deberia dar error al fallar la conexion con la BD', async t => {
+  // reconectandose a la BD
+  logs = await Log({
+    database: 'WsomeRandomNombre',
+    username: parseInt(Math.random() * 1000) + '_db',
+    password: parseInt(Math.random() * 1000) + 'password',
+    host: 'localhost'
+  }).catch(handleFatalError);
+
+  const log = await logs.info('No se guarda');
+  t.is(log, undefined, 'No se pudo guardar logs logs');
 });


### PR DESCRIPTION
Ahora app-logs captura el error y evita que la aplicación que lo usa caiga en los casos:

- Cuando se pierde la conexión a la Base de datos.
- Cuando no se puede escribir logs en el archivo indicado.